### PR TITLE
Gutenberg content updates

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -12,10 +12,9 @@
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<arg value="spn"/> <!-- Show sniff and progress -->
-	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
-	<arg name="parallel" value="8"/><!-- Enables parallel processing when available for faster results. -->
+	<arg name="parallel" value="1"/><!-- Enables parallel processing when available for faster results. -->
 
 	<rule ref="WordPress" />
 	<rule ref="WordPressVIPMinimum" />

--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -39,7 +39,6 @@ class Gutenberg_Content extends Component {
 						apply_filters( 'the_content', $this->post->post_content ?? '' )
 					)
 			);
-
 		} else {
 			$blocks = (array) parse_blocks( $this->post->post_content ?? '' );
 
@@ -55,53 +54,47 @@ class Gutenberg_Content extends Component {
 				)
 			);
 
-			$blocks_as_components = array_map( [ $this, 'convert_block_to_component' ], $blocks );
+			$blocks_as_components = array_reduce( $blocks, [ $this, 'convert_block_to_component' ], [] );
 			$this->append_children( $blocks_as_components );
 		}
 
 		return $this;
 	}
 
-
 	/**
 	 * Map a block array to a Component instance.
 	 *
 	 * @todo: Create "columns" and "column" components that can handle placing child blocks within the wrapping markup.
 	 *
-	 * @param array $block A parsed block associative array.
+	 * @param array $blocks         Accumulated array of blocks.
+	 * @param array $current_block  Current block.
 	 * @return object Component instance
 	 */
-	private function convert_block_to_component( $block ) : object {
-
-		$block = (array) $block;
+	private function convert_block_to_component( $blocks, $current_block ) : array {
+		$block = (array) $current_block;
 
 		// Handle gutenberg embeds.
 		if ( strpos( $block['blockName'] ?? '', 'core-embed' ) === 0 ) {
-			return ( new Blocks\Core_Embed() )->set_from_block( $block );
+			$blocks[] = ( new Blocks\Core_Embed() )->set_from_block( $block );
+			return $blocks;
 		}
 
 		// The presence of html means this is a non dynamic block.
 		if ( ! empty( $block['innerHTML'] ) ) {
-			$content = $block['innerHTML'];
+			$content = $this->get_block_html_content( $block );
+			$last_block = end( $blocks );
 
-			// Missing blockName means it's a "classic" block, run the_content.
-			if ( empty( $block['blockName'] ) ) {
-				$content = apply_filters( 'the_content', $content );
+			// Merge non-dynamic block content into a single HTML component.
+			if ( $last_block instanceof HTML ) {
+				$last_block->set_config(
+					'content',
+					$last_block->get_config( 'content' ) . $content
+				);
+			} else {
+				$blocks[] = ( new HTML() )->set_config( 'content', $content );
 			}
 
-			// Clean up extraneous whitespace characters.
-			$content = preg_replace( '/[\r\n\t\f\v]/', '', $content );
-
-			// Handle nested blocks.
-			$children_blocks_as_components = array_map(
-				[ $this, 'convert_block_to_component' ],
-				(array) ( $block['innerBlocks'] ?? [] )
-			);
-
-			return ( new HTML() )
-				->merge_config( $block['attrs'] ?? [] )
-				->set_config( 'content', $content )
-				->append_children( $children_blocks_as_components );
+			return $blocks;
 		}
 
 		// Handle nested blocks.
@@ -111,9 +104,48 @@ class Gutenberg_Content extends Component {
 		);
 
 		// A dynamic block. All attributes will be available.
-		( new Component() )
+		$blocks[] = ( new Component() )
 			->set_name( $block['blockName'] ?? '' )
 			->merge_config( $block['attrs'] ?? [] )
 			->append_children( $children_blocks_as_components );
+
+		return $blocks;
+	}
+
+	/**
+	 * Map a block array to a Component instance.
+	 *
+	 * @todo: Create "columns" and "column" components that can handle placing child blocks within the wrapping markup.
+	 *
+	 * @param array $block Gutenberg block from which to retrieve HTMl content.
+	 * @return string HTMl content of gutenberg block.
+	 */
+	public function get_block_html_content( $block ) : string {
+		$content = '';
+		$inner_blocks = $block['innerBlocks'];
+
+		// Loop through inner content if it's not empty.
+		if ( ! empty( $block['innerContent'] ) ) {
+			foreach ( $block['innerContent'] as $inner_content ) {
+				// Add inner content item if it's not empty, otherwise add content of inner blocks.
+				if ( ! empty( $inner_content ) ) {
+					$content .= $inner_content;
+				} else if ( ! empty( $inner_blocks ) ) {
+					$content .= $this->get_block_html_content( array_shift( $inner_blocks ) );
+				}
+			}
+		} else {
+			$content = $block['innerHTML'];
+		}
+
+		// Missing blockName means it's a "classic" block, run the_content.
+		if ( empty( $block['blockName'] ) ) {
+			$content = apply_filters( 'the_content', $content );
+		}
+
+		// Clean up extraneous whitespace characters.
+		$content = preg_replace( '/[\r\n\t\f\v]/', '', $content );
+
+		return $content;
 	}
 }

--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -81,7 +81,7 @@ class Gutenberg_Content extends Component {
 
 		// The presence of html means this is a non dynamic block.
 		if ( ! empty( $block['innerHTML'] ) ) {
-			$content = $this->get_block_html_content( $block );
+			$content = $this->get_static_block_html_content( $block );
 			$last_block = end( $blocks );
 
 			// Merge non-dynamic block content into a single HTML component.
@@ -120,7 +120,7 @@ class Gutenberg_Content extends Component {
 	 * @param array $block Gutenberg block from which to retrieve HTMl content.
 	 * @return string HTMl content of gutenberg block.
 	 */
-	public function get_block_html_content( $block ) : string {
+	public function get_static_block_html_content( $block ) : string {
 		$content = '';
 		$inner_blocks = $block['innerBlocks'];
 


### PR DESCRIPTION
Updates to fix two issues:
* Core blocks and/or any non-dynamically-rendered block need to be merged into the content of a single HTML component, otherwise we end up with a bunch of `<div>` wrappers that prevent properly laying out blocks. This is b/c we need to use `dangerouslySetInnerHTML` to render those blocks on the frontend, and we can't do that on a `Fragment` (yet)
* Core blocks that can contain any other block (afaik just columns) need to be rendered dynamically so as to allow custom inner blocks.