### PR TITLE
Use custom excerpt function which overrides global

### DIFF
--- a/inc/wp-components/classes/class-head.php
+++ b/inc/wp-components/classes/class-head.php
@@ -392,7 +392,7 @@ class Head extends Component {
 			return $meta_description;
 		}
 
-		return get_the_excerpt( $this->post->ID );
+		return $this->wp_post_get_excerpt();
 	}
 
 	/**


### PR DESCRIPTION
We can't use `get_the_excerpt()` as-is; use our custom `wp_post_get_excerpt()` which modifies the global state before calling `get_the_excerpt()`