### PR TITLE
Add callable method to component class

### DIFF
--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -231,6 +231,17 @@ class Component implements \JsonSerializable {
 	}
 
 	/**
+	 * Run a user callback on this class. This can be used to create a fork in
+	 * the method chain.
+	 *
+	 * @param callable $callable Callable.
+	 * @return function
+	 */
+	public function callback( $callable ) {
+		return call_user_func_array( $callable, [ &$this ] );
+	}
+
+	/**
 	 * Execute a function on each child of this component.
 	 *
 	 * @param callable $callback Callback function.


### PR DESCRIPTION
Using the `callable` method, you can easily create a fork during a method chain. This means you can conditionally execute code _when_ you need it, rather than before the return statement begins.

```
// While inside the return array.
return [
	/**
	 * Hero component.
	 *
	 * This has 2 themes, jumbo and overlay.
	 */
	( new \WP_Components\Hero() )
		->callable(
			function( $hero ) : \WP_Components\Hero {

				// We've essentially given ourselves a fork in the chain to do
				// whatever we'd like. The component we're chaining is available
				// in the anonymous function, so as long as we return that,
				// we're good. We can still access the class with $this.
				switch ( $this->post->post_type ) {
					case 'post':
						$hero->set_theme( 'jumbo' );
						break;
					case 'page': 
						$hero->set_theme( 'overlay' );
						break;
					default:
						break;
				}

				// Return the component so the chain can continue.
				return $hero;
			}
		)
		->get_config( 'theme_name' ),

	// More components.
];
```