### PR TITLE
CPR-672: Editing class-social-sharing to format return for email share

### DIFF
--- a/inc/wp-components/classes/class-social-sharing.php
+++ b/inc/wp-components/classes/class-social-sharing.php
@@ -166,6 +166,8 @@ class Social_Sharing extends Component {
 
 	/**
 	 * Get an Email Social_item component.
+	 * Sets the subject to the item's title, and
+	 * the email body to the URL of the item being shared
 	 *
 	 * @return \WP_Components\Social_item
 	 */
@@ -176,9 +178,8 @@ class Social_Sharing extends Component {
 					'type' => 'email',
 					'url'  => add_query_arg(
 						[
-							'url'         => $this->get_url(),
-							'media'       => $this->get_featured_image_url(),
-							'description' => $this->get_excerpt(),
+							'subject' => $this->get_title(),
+							'body'    => $this->get_url(),
 						],
 						'mailto:'
 					),


### PR DESCRIPTION
Email social item was returning url/media/description parameters which aren't usable in the "mailto" link that is returned.
This commit just changes the return to include "subject" (post title), and "body" (URL to post) so that emails will be auto-filled.