### PR TITLE
Only include an image attachment when the image has been set.

### DIFF
--- a/inc/wp-components/traits/trait-wp-post.php
+++ b/inc/wp-components/traits/trait-wp-post.php
@@ -198,13 +198,17 @@ trait WP_Post {
 	 * @return object Instance of the class this trait is implemented on.
 	 */
 	public function wp_post_set_featured_image( $size = 'full', $config = [] ) : self {
-		return $this->append_children(
-			[
-				( new \WP_Components\Image() )
-					->set_post_id( $this->get_post_id() )
-					->set_config_for_size( $size )
-					->merge_config( $config ),
-			]
-		);
+		if ( has_post_thumbnail( $this->get_post_id() ) ) {
+			return $this->append_children(
+				[
+					( new \WP_Components\Image() )
+						->set_post_id( $this->get_post_id() )
+						->set_config_for_size( $size )
+						->merge_config( $config ),
+				]
+			);
+		}
+
+		return $this;
 	}
 }


### PR DESCRIPTION
Fixes issue that an image will appear in the response even when the editor has set no featured image.