### PR TITLE
Do not call callback if key is an array

### DIFF
--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -116,12 +116,12 @@ class Component implements \JsonSerializable {
 			$this->config = $key;
 		} else {
 			$this->config[ $key ] = $value;
-		}
 
-		// Allow hooking into a config being set.
-		$callback_method = "{$key}_config_has_set";
-		if ( method_exists( $this, $callback_method ) && $do_callback ) {
-			$this->$callback_method();
+			// Allow hooking into a config being set.
+			$callback_method = "{$key}_config_has_set";
+			if ( method_exists( $this, $callback_method ) && $do_callback ) {
+				$this->$callback_method();
+			}
 		}
 
 		return $this;


### PR DESCRIPTION
Fixes a warning when `$key` is an array. 