### PR TITLE
Add functionality for creating additional arbitrary groups of components (besides `children`

### DIFF
--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -34,6 +34,13 @@ class Component implements \JsonSerializable {
 	public $children = [];
 
 	/**
+	 * Component groups.
+	 *
+	 * @var array
+	 */
+	public $component_groups = [];
+
+	/**
 	 * Determine which config keys should be passed into result.
 	 *
 	 * @var array
@@ -242,6 +249,39 @@ class Component implements \JsonSerializable {
 	}
 
 	/**
+	 * Append a component or components to a particular component group.
+	 *
+	 * @param string          $group Group or array of components.
+	 * @param array|Component $children Child component.
+	 * @return self
+	 */
+	public function append_to_group( $group, $children = [] ) : self {
+		if ( in_array( $group, $this->component_groups, true ) ) {
+			$children = ! is_array( $children ) ? [ $children ] : $children;
+			array_push( $this->component_groups[ $group ], $children );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Prepend a component or components to a particular component group.
+	 *
+	 * @param string          $group Group or array of components.
+	 * @param array|Component $children Child component.
+	 * @return self
+	 */
+	public function prepend_to_group( $group, $children ) : self {
+		// If group exists, add components to it.
+		if ( in_array( $group, $this->component_groups, true ) ) {
+			$children = ! is_array( $children ) ? [ $children ] : $children;
+			array_push( $children, $this->component_groups[ $group ] );
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Render the frontend component.
 	 */
 	public function render() {
@@ -389,9 +429,15 @@ class Component implements \JsonSerializable {
 		}
 
 		return [
-			'name'     => $this->name,
-			'config'   => (object) $this->camel_case_keys( $this->config ),
-			'children' => array_filter( $this->children ),
+			'name'            => $this->name,
+			'config'          => (object) $this->camel_case_keys( $this->config ),
+			'children'        => array_filter( $this->children ),
+			'componentGroups' => array_map(
+				function ( $group ) {
+					return arra_filter( $group );
+				},
+				$this->component_groups
+			),
 		];
 	}
 

--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -148,11 +148,7 @@ class Component implements \JsonSerializable {
 			return array_reduce(
 				$components,
 				function ( $carry, $component ) {
-					if ( true === $carry && $component instanceof Component ) {
-						return true;
-					} else {
-						return false;
-					}
+					return ! $carry ? $carry : $component instanceof Component;
 				},
 				true
 			);
@@ -241,7 +237,7 @@ class Component implements \JsonSerializable {
 	}
 
 	/**
-	 * Appen an array of components to the children array or component group.
+	 * Append an array of components to the children array or component group.
 	 *
 	 * @param string|array $group Group or array of components.
 	 * @param array        $children Child components.
@@ -310,7 +306,7 @@ class Component implements \JsonSerializable {
 			$child = $child[0];
 		}
 
-		// Push to group if group is valid, otherwise push to children.
+		// Unshift to group if group is valid, otherwise unshift to children.
 		if ( $this->is_valid_group( $group ) && ! empty( $child ) ) {
 			array_unshift( $this->component_groups[ $group ], $child );
 		} elseif ( $this->is_component( $group ) ) {
@@ -342,10 +338,10 @@ class Component implements \JsonSerializable {
 	 * Execute a function on each child of this component.
 	 *
 	 * @param string        $group Component group on which to call the callback.
-	 * @param callable|bool $callback Callback function.
+	 * @param callable|null $callback Callback function.
 	 * @return self
 	 */
-	public function children_callback( $group, $callback = false ) : self {
+	public function children_callback( $group, $callback = null ) : self {
 		// If valid group, map over the group, otherwise map over children.
 		if ( $this->is_valid_group( $group ) ) {
 			$this->component_groups[ $group ] = array_map( $callback, $this->component_groups[ $group ] );

--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -336,16 +336,13 @@ class Component implements \JsonSerializable {
 	 * @return self
 	 */
 	public function set_theme( $theme_name ) : self {
-
-		// Camel case the theme name, if it isn't already.
-		$theme_name = $this->camel_case_string( $theme_name );
-
 		// Only set theme if it's configured in the themes property OR no other themes are configured (besides `default`), implicitly indicating theme validation should not be used.
 		if (
 			in_array( $theme_name, $this->themes, true )
 			|| ( 1 === count( $this->themes ) && 'default' === $this->themes[0] )
 		) {
-			return $this->set_config( 'theme_name', $theme_name );
+			// Return camel cased theme name, if it isn't camel cased already.
+			return $this->set_config( 'theme_name', $this->camel_case_string( $theme_name ) );
 		}
 
 		// Set theme to 'default' if the theme is not configured.

--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -38,7 +38,10 @@ class Component implements \JsonSerializable {
 	 *
 	 * @var array
 	 */
-	public $component_groups = [];
+	public $component_groups = [
+		// Add default to make sure it's sent over as a JSON object.
+		'default' => [],
+	];
 
 	/**
 	 * Determine which config keys should be passed into result.
@@ -270,9 +273,9 @@ class Component implements \JsonSerializable {
 	 * @return self
 	 */
 	public function append_to_group( $group, $children = [] ) : self {
-		if ( in_array( $group, $this->component_groups, true ) ) {
+		if ( in_array( $group, array_keys( $this->component_groups ), true ) ) {
 			$children = ! is_array( $children ) ? [ $children ] : $children;
-			array_push( $this->component_groups[ $group ], $children );
+			$this->component_groups[ $group ] = array_merge( $this->component_groups[ $group ], $children );
 		}
 
 		return $this;
@@ -289,7 +292,7 @@ class Component implements \JsonSerializable {
 		// If group exists, add components to it.
 		if ( in_array( $group, $this->component_groups, true ) ) {
 			$children = ! is_array( $children ) ? [ $children ] : $children;
-			array_push( $children, $this->component_groups[ $group ] );
+			$this->component_groups[ $group ] = array_merge( $children, $this->component_groups[ $group ] );
 		}
 
 		return $this;
@@ -459,7 +462,7 @@ class Component implements \JsonSerializable {
 			'children'        => array_filter( $this->children ),
 			'componentGroups' => array_map(
 				function ( $group ) {
-					return arra_filter( $group );
+					return array_filter( $group );
 				},
 				$this->component_groups
 			),

--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -115,7 +115,7 @@ class Component implements \JsonSerializable {
 	/**
 	 * Check if a provided component group is valid.
 	 *
-	 * @param mixed $group Group to get.
+	 * @param mixed $group Group to check.
 	 * @return bool
 	 */
 	public function is_valid_group( $group ): bool {

--- a/inc/wp-components/classes/helpers/class-link.php
+++ b/inc/wp-components/classes/helpers/class-link.php
@@ -17,7 +17,7 @@ class Link extends \WP_Components\Component {
 	 *
 	 * @var string
 	 */
-	public $name = 'link';
+	public $name = 'link-to';
 
 	/**
 	 * Define a default config.
@@ -26,7 +26,7 @@ class Link extends \WP_Components\Component {
 	 */
 	public function default_config(): array {
 		return [
-			'blank' => '',
+			'blank' => false,
 			'to'    => '',
 		];
 	}


### PR DESCRIPTION
This should make layout easier and allow for the creation of "template areas" or something similar.

Also fix naming of link component b/c `link` is a real HTML tag.