### PR TITLE
Byline manager updates

### DIFF
--- a/inc/wp-components/classes/class-byline-wrapper.php
+++ b/inc/wp-components/classes/class-byline-wrapper.php
@@ -113,6 +113,12 @@ class Byline_Wrapper extends Component {
 								return $byline->set_byline_manager_profile( $byline_entry->get_post() );
 							}
 
+							if (
+								$byline_entry instanceof \Byline_Manager\Models\TextProfile
+							) {
+								return $byline->set_config( 'name', $byline_entry->atts['text'] );
+							}
+
 							return $byline;
 						}
 					);

--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -302,7 +302,7 @@ class Component implements \JsonSerializable {
 	 * @return self
 	 */
 	public function prepend_child( $group, $child = [] ) : self {
-		if ( is_array( $child ) ) {
+		if ( is_array( $child ) && ! empty( $child ) ) {
 			$child = $child[0];
 		}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -74,4 +74,8 @@
 		<type>warning</type>
 	</rule>
 
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
This PR addresses 2 issues:
- Checks for empty array in the `prepend_child()` in class-component.php to prevent an undefined index notice.
- Adds support for text profiles from the Byline Manager plugin in the byline wrapper component.