### PR TITLE
Broken Image Credits

### DIFF
--- a/inc/wp-components/classes/class-image.php
+++ b/inc/wp-components/classes/class-image.php
@@ -212,7 +212,7 @@ class Image extends Component {
 	 */
 	public function set_config_for_size( string $image_size, $picture = false ): self {
 		// Call configure method.
-		return $this->configure( $this->get_config( 'attachment_id' ), $image_size, $picture );
+		return $this->configure( $this->get_config( 'id' ), $image_size, $picture );
 	}
 
 	/**


### PR DESCRIPTION
A recent commit to class-image.php changed the config key 'attachment_id' to 'id', breaking some image config calls. This just fixes the other use of 'attachment_id' in this class.

@ostowe  - Tagging you here, in case this other usage was left this way on purpose (don't want to break what you were working on).
Thanks all!