### PR TITLE
Revert "Run Gutenberg content through post content filters"

### DIFF
--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -27,7 +27,7 @@ class Gutenberg_Content extends Component {
 	 * @return self
 	 */
 	public function post_has_set() : self {
-		$components = $this->parse_and_convert_block_content( $this->wp_post_get_content() );
+		$components = $this->parse_and_convert_block_content( $this->post->post_content ?? '' );
 
 		return $this->append_children( $components );
 	}

--- a/inc/wp-components/traits/trait-wp-post.php
+++ b/inc/wp-components/traits/trait-wp-post.php
@@ -190,15 +190,6 @@ trait WP_Post {
 	}
 
 	/**
-	 * Get the post content.
-	 *
-	 * @return string
-	 */
-	public function wp_post_get_content(): string {
-		return apply_filters( 'the_content', $this->post->post_content ?? '' );
-	}
-
-	/**
 	 * Create Image component and append to children.
 	 *
 	 * @param string $size Image size to use for child image component.


### PR DESCRIPTION
Reverts alleyinteractive/wp-components#104

This needs to be addressed in a different manner since we've built a lot of logic on being able to parse out blocks before content filters run