### PR TITLE
Post convert blocks

### DIFF
--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -74,6 +74,12 @@ class Gutenberg_Content extends Component {
 			)
 		);
 
+		$blocks = apply_filters(
+			'wp_components_pre_convert_blocks',
+			$blocks,
+			$this
+		);
+
 		$components = array_reduce( $blocks, [ $this, 'convert_block_to_component' ], [] );
 
 		return $components ?? [];

--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -79,8 +79,8 @@ class Gutenberg_Content extends Component {
 		/**
 		 * Filters the array of blocks after they're converted to components.
 		 *
-		 * @param array $blocks Parsed array of blocks.
-		 * @param array $this   Current component instance.
+		 * @param array $components Array of compoents created from parsed Gutenberg blocks.
+		 * @param array $this       Current component instance.
 		 */
 		$components = apply_filters(
 			'wp_components_post_convert_blocks',

--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -74,13 +74,19 @@ class Gutenberg_Content extends Component {
 			)
 		);
 
-		$blocks = apply_filters(
-			'wp_components_pre_convert_blocks',
-			$blocks,
+		$components = array_reduce( $blocks, [ $this, 'convert_block_to_component' ], [] );
+
+		/**
+		 * Filters the array of blocks after they're converted to components.
+		 *
+		 * @param array $blocks Parsed array of blocks.
+		 * @param array $this   Current component instance.
+		 */
+		$components = apply_filters(
+			'wp_components_post_convert_blocks',
+			$components,
 			$this
 		);
-
-		$components = array_reduce( $blocks, [ $this, 'convert_block_to_component' ], [] );
 
 		return $components ?? [];
 	}


### PR DESCRIPTION
Add a `wp_componets_post_convert_blocks` filter for modifying components after they've been created from Gutenberg blocks.