### PR TITLE
Fix issue with global $post

### DIFF
--- a/inc/wp-components/traits/trait-attachment.php
+++ b/inc/wp-components/traits/trait-attachment.php
@@ -22,8 +22,7 @@ trait Attachment {
 	/**
 	 * Set the post object.
 	 *
-	 * @param mixed $attachment Post object, post ID, or null to use global $post
-	 *                    object.
+	 * @param mixed $attachment Attachment object or post ID.
 	 * @return object Instance of the class this trait is implemented on.
 	 */
 	public function set_attachment( $attachment = null ) : self {
@@ -36,16 +35,16 @@ trait Attachment {
 
 		// Post ID was passed.
 		if ( 0 !== absint( $attachment ) ) {
-			$post = get_post( $attachment );
+			$attachment_post = get_post( $attachment );
 
-			if ( 'post' === $post->post_type ) {
-				$attachment_id = get_post_thumbnail_id( $post );
-				$post          = get_post( $attachment_id );
+			if ( ! empty( $attachment_post->post_type ) && 'attachment' !== $attachment_post->post_type ) {
+				$attachment_id   = get_post_thumbnail_id( $attachment_post );
+				$attachment_post = get_post( $attachment_id );
 			}
 
 			// Don't set post if empty.
-			if ( ! empty( $post ) ) {
-				$this->set_attachment( $post );
+			if ( ! empty( $attachment_post ) ) {
+				$this->set_attachment( $attachment_post );
 			}
 
 			return $this;
@@ -151,11 +150,11 @@ trait Attachment {
 		}
 
 		// Use image description as final fallback.
-		$post = get_post( $this->get_attachment_id() );
-		if ( $post ) {
+		$attachment_post = get_post( $this->get_attachment_id() );
+		if ( $attachment_post ) {
 			// We can't rely on get_the_excerpt(), because it relies on The Loop
 			// global variables that are not correctly set within the Irving context.
-			return esc_attr( $post->post_excerpt );
+			return esc_attr( $attachment_post->post_excerpt );
 		}
 
 		return '';

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -72,11 +72,12 @@ class Image_Tests extends WP_UnitTestCase {
 				],
 			]
 		);
+
 		// insert a post.
 		$this->post = $this->factory->post->create_and_get(
 			array(
 				'post_title' => rand_str(),
-				'post_date'  => '2009-07-01 00:00:00',
+				'post_date'  => '2020-01-01 00:00:00',
 			)
 		);
 	}
@@ -224,7 +225,7 @@ class Image_Tests extends WP_UnitTestCase {
 		$this->image->configure( 0, 'this-size-should-not-exist' );
 
 		$this->assertEquals(
-			$this->image->get_config( 'url' ),
+			$this->image->get_config( 'src' ),
 			$this->image::$fallback_image_url
 		);
 	}
@@ -248,7 +249,7 @@ class Image_Tests extends WP_UnitTestCase {
 		$this->image->configure( 0, 'this-size-should-not-exist' );
 		$this->assertEquals(
 			'http://example.org/wp-content/uploads/image.jpg',
-			$this->image->get_config( 'url' )
+			$this->image->get_config( 'src' )
 		);
 	}
 
@@ -259,7 +260,40 @@ class Image_Tests extends WP_UnitTestCase {
 		$this->image->configure( 0, 'test' );
 		$this->assertEquals(
 			'http://example.org/wp-content/uploads/fallback.jpg',
-			$this->image->get_config( 'url' )
+			$this->image->get_config( 'src' )
+		);
+	}
+
+	/**
+	 * Test that image component will not rely on global $post and use fallbacks approrpriately,
+	 * instead of fallinb back to image attached to global $post.
+	 */
+	public function test_missing_image() {
+		// insert a second post.
+		$post_two = $this->factory->post->create_and_get(
+			array(
+				'post_title' => rand_str(),
+				'post_date'  => '2020-01-01 00:00:00',
+			)
+		);
+
+		// Add thumbnail to first post, but not second
+		update_post_meta(
+			$this->post->ID,
+			'_thumbnail_id',
+			self::$attachment_id
+		);
+
+		$image_one = ( new \WP_Components\Image() )->configure( self::$attachment_id, 'test' );
+		$image_two = ( new \WP_Components\Image() )->configure( 123456, 'test' );
+
+		$this->assertEquals(
+			'http://example.org/wp-content/uploads/2019/12/test-image.jpg',
+			$image_one->get_config( 'src' )
+		);
+		$this->assertEquals(
+			'http://example.org/wp-content/uploads/fallback.jpg',
+			$image_two->get_config( 'src' )
 		);
 	}
 

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -286,8 +286,10 @@ class Image_Tests extends WP_UnitTestCase {
 			self::$attachment_id
 		);
 
+		// Set global post
 		$post = $this->post;
 
+		// Create image components
 		$image_one = ( new \WP_Components\Image() )->configure( self::$attachment_id, 'test' );
 		$image_two = ( new \WP_Components\Image() )->configure( $post_two->ID, 'test' );
 

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -269,6 +269,8 @@ class Image_Tests extends WP_UnitTestCase {
 	 * instead of fallinb back to image attached to global $post.
 	 */
 	public function test_missing_image() {
+		global $post;
+
 		// insert a second post.
 		$post_two = $this->factory->post->create_and_get(
 			array(
@@ -284,8 +286,10 @@ class Image_Tests extends WP_UnitTestCase {
 			self::$attachment_id
 		);
 
+		$post = $this->post;
+
 		$image_one = ( new \WP_Components\Image() )->configure( self::$attachment_id, 'test' );
-		$image_two = ( new \WP_Components\Image() )->configure( 123456, 'test' );
+		$image_two = ( new \WP_Components\Image() )->configure( $post_two->ID, 'test' );
 
 		$this->assertEquals(
 			'http://example.org/wp-content/uploads/2019/12/test-image.jpg',


### PR DESCRIPTION
attachment trait was relying on a local variable $post which was getting mixed up with global $post, rename variable to $attachment_post