### PR TITLE
Modify the image test so that it does not rely on date

### DIFF
--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -293,8 +293,8 @@ class Image_Tests extends WP_UnitTestCase {
 		$image_one = ( new \WP_Components\Image() )->configure( self::$attachment_id, 'test' );
 		$image_two = ( new \WP_Components\Image() )->configure( $post_two->ID, 'test' );
 
-		$this->assertEquals(
-			'http://example.org/wp-content/uploads/2019/12/test-image.jpg',
+		$this->assertStringEndsWith(
+			'/test-image.jpg',
 			$image_one->get_config( 'src' )
 		);
 		$this->assertEquals(

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -265,8 +265,8 @@ class Image_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that image component will not rely on global $post and use fallbacks approrpriately,
-	 * instead of fallinb back to image attached to global $post.
+	 * Test that image component will not rely on global $post and use fallbacks appropriately,
+	 * instead of falling back to image attached to global $post.
 	 */
 	public function test_missing_image() {
 		global $post;


### PR DESCRIPTION
The date isn't the important part; the important aspect is that the `test-image.jpg` is returned