### PR TITLE
IRV-257 Ensure the URL in the block HTML matches the attributes URL

### DIFF
--- a/inc/wp-components/classes/blocks/class-core-embed.php
+++ b/inc/wp-components/classes/blocks/class-core-embed.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gutenberg Content component.
+ * Core Embed component.
  *
  * @package WP_Components
  */
@@ -8,7 +8,7 @@
 namespace WP_Components\Blocks;
 
 /**
- * Gutenberg Content.
+ * Core Embed.
  */
 class Core_Embed extends \WP_Components\Component {
 
@@ -106,7 +106,7 @@ class Core_Embed extends \WP_Components\Component {
 			);
 		}
 		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$content = str_replace( $block['attrs']['url'], $doc->saveHTML(), $block['innerHTML'] );
+		$content = str_replace( $block['attrs']['url'], $doc->saveHTML(), html_entity_decode( $block['innerHTML'] ) );
 
 		// Restore original error optional value.
 		libxml_use_internal_errors( false );


### PR DESCRIPTION
Bug: A Facebook post URL with query params was embedded to a post, yet it did not render as an embed on the front end.

Cause: The URL within the block attributes had `&` as `&`, whereas within the block's innerHTML it was encoded to `&amp`, therefore the str_replace wasn't matching. 