### PR TITLE
Callback to allow component injection in WP Blocks

### DIFF
--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -23,6 +23,8 @@ class Gutenberg_Content extends Component {
 
 	/**
 	 * Callback to inject components in the component array
+	 *
+	 * @var callable
 	 */
 	private $components_callback = null;
 
@@ -39,9 +41,13 @@ class Gutenberg_Content extends Component {
 
 	/**
 	 * Provide a callback to inject a component
+	 *
+	 * @param callable $cb function to run during block processing.
+	 * @return self
 	 */
-	public function set_components_callback( Callable $cb ) {
+	public function set_components_callback( callable $cb ) {
 		$this->components_callback = $cb;
+		return $this;
 	}
 
 	/**

--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -22,6 +22,11 @@ class Gutenberg_Content extends Component {
 	public $name = 'gutenberg-content';
 
 	/**
+	 * Callback to inject components in the component array
+	 */
+	private $components_callback = null;
+
+	/**
 	 * Fires after the post object has been set on this class.
 	 *
 	 * @return self
@@ -30,6 +35,13 @@ class Gutenberg_Content extends Component {
 		$components = $this->parse_and_convert_block_content( $this->post->post_content ?? '' );
 
 		return $this->append_children( $components );
+	}
+
+	/**
+	 * Provide a callback to inject a component
+	 */
+	public function set_components_callback( Callable $cb ) {
+		$this->components_callback = $cb;
 	}
 
 	/**
@@ -105,6 +117,10 @@ class Gutenberg_Content extends Component {
 			],
 			$block
 		);
+
+		if ( $this->components_callback ) {
+			$blocks = call_user_func( $this->components_callback, $blocks );
+		}
 
 		// If there's no block name, but there is innerHTML.
 		if (

--- a/inc/wp-components/classes/class-gutenberg-content.php
+++ b/inc/wp-components/classes/class-gutenberg-content.php
@@ -136,7 +136,7 @@ class Gutenberg_Content extends Component {
 			$block
 		);
 
-		if ( $this->components_callback ) {
+		if ( is_callable( $this->components_callback ) ) {
 			$blocks = call_user_func( $this->components_callback, $blocks );
 		}
 


### PR DESCRIPTION
* Allows a callback to be supplied to `Gutenberg_Content` that is run each time a block is converted to a component and added to the component stack.
* The callback runs immediately before `Gutenberg_Content::merge_or_create_html_block` to allow the developer to inject a component between two blocks that would otherwise be merged together.