### PR TITLE
Use a less aggressive strip_tag function

### DIFF
--- a/inc/wp-components/classes/integrations/class-yoast-schema.php
+++ b/inc/wp-components/classes/integrations/class-yoast-schema.php
@@ -74,6 +74,6 @@ class Yoast_Schema extends \WP_Components\Component {
 			return '';
 		}
 
-		return wp_strip_all_tags( $schema );
+		return strip_tags( $schema );
 	}
 }


### PR DESCRIPTION
Using a less aggressive strip_tag function since the WP one is removing the JSON part as well.