### PR TITLE
Remove any lingering query string on original image URL

### DIFF
--- a/inc/wp-components/classes/class-image.php
+++ b/inc/wp-components/classes/class-image.php
@@ -198,7 +198,7 @@ class Image extends Component {
 			[
 				'crops' => array_filter( $crops ),
 				'id'    => $this->get_attachment_id(),
-				'url'   => $this->get_attachment_src( 'full' ),
+				'url'   => strtok( $this->get_attachment_src( 'full' ), '?' ),
 			]
 		);
 	}


### PR DESCRIPTION
This seems to only be an issue when photon is in use (sometimes the `full` image size will return a URL with photon params applied). Perhaps we can include integration tests somehow, at some point.